### PR TITLE
style: replace tabs with spaces in sample-graceful-shutdown/sample.js

### DIFF
--- a/sample-graceful-shutdown/sample.js
+++ b/sample-graceful-shutdown/sample.js
@@ -14,7 +14,7 @@
 
 // quit on ctrl-c when running docker in terminal
 process.on('SIGINT', function onSigint () {
-	console.info('Got SIGINT (aka ctrl-c in docker). Graceful shutdown ', new Date().toISOString());
+  console.info('Got SIGINT (aka ctrl-c in docker). Graceful shutdown ', new Date().toISOString());
   shutdown();
 });
 
@@ -32,7 +32,7 @@ function shutdown() {
     if (err) {
       console.error(err);
       process.exitCode = 1;
-		}
-		process.exit();
+    }
+    process.exit();
   })
 }


### PR DESCRIPTION
for a consistent look outside modern text editors